### PR TITLE
update the redshift__type_string to varchar(6000).

### DIFF
--- a/macros/cross_db_shim/redshift_shims.sql
+++ b/macros/cross_db_shim/redshift_shims.sql
@@ -1,3 +1,3 @@
 {%- macro redshift__type_string() -%}
-  {{ "VARCHAR(600)" }}
+  {{ "VARCHAR(6000)" }}
 {%- endmacro %}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes
- [ ] new functionality

## Link to Issue 
<!---
Include this section if you are closing an open issue
e.g. 
Closes #13
-->


## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Integration Test Screenshot
<!---
Screenshot of passing integration tests locally
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
    - [ ] Databricks
    - [ ] DuckDB
    - [ ] Trino/Starburst
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)